### PR TITLE
fix: infinite loop on the find_cached_dir function on the Windows OS

### DIFF
--- a/lua/live-server.lua
+++ b/lua/live-server.lua
@@ -13,7 +13,7 @@ local function find_cached_dir(dir)
     local cur = dir
 
     while not job_cache[cur] do
-        if cur == '/' then
+        if cur == '/' or string.match(cur, '^[A-Z]:\\$') then
             return
         end
 


### PR DESCRIPTION
The `find_cached_dir()` function tries to check for the root directory of the system. However, the root directory differ between Linux('/') and Windows('C:\') systems. A regex match(`string.match()`) was used to compensate the fact that Windows can have different drive letters('D:\', 'E:\', ...).