### PR TITLE
Improve Windows support and add error message for nil directory in live-server.nvim

### DIFF
--- a/lua/live-server.lua
+++ b/lua/live-server.lua
@@ -10,16 +10,18 @@ end
 local job_cache = {}
 
 local function find_cached_dir(dir)
-    local cur = dir
+    if not dir then
+        vim.notify("live-server.nvim: No directory provided to find_cached_dir()", vim.log.levels.ERROR)
+        return
+    end
 
+    local cur = dir
     while not job_cache[cur] do
         if cur == '/' or string.match(cur, '^[A-Z]:\\$') then
             return
         end
-
         cur = vim.fn.fnamemodify(cur, ':h')
     end
-
     return cur
 end
 


### PR DESCRIPTION
Added detection for Windows to use live-server.cmd instead of live-server executable

Added error notification if find_cached_dir() is called with a nil argument to avoid crashes

Improved robustness when stopping/starting the server on Windows