### PR TITLE
docs: modernize readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Live reload HTML, CSS, and JavaScript files inside Neovim with the power of
 
 ## Installation
 
-Install using your package manager of choice or via
+Install with your package manager or via
 [luarocks](https://luarocks.org/modules/barrettruth/live-server.nvim):
 
 ```
@@ -14,30 +14,7 @@ luarocks install live-server.nvim
 
 ## Dependencies
 
-- [live-server](https://www.npmjs.com/package/live-server) (install globally via
-  npm/pnpm/yarn)
-
-## Configuration
-
-Configure via `vim.g.live_server` before the plugin loads:
-
-```lua
-vim.g.live_server = {
-  args = { '--port=5555' },
-}
-```
-
-See `:help live-server` for available options.
-
-## Usage
-
-```vim
-:LiveServerStart [dir]   " Start the server
-:LiveServerStop [dir]    " Stop the server
-:LiveServerToggle [dir]  " Toggle the server
-```
-
-The server runs by default on `http://localhost:5555`.
+- [live-server](https://www.npmjs.com/package/live-server) (install globally via npm/yarn)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Remove configuration and usage sections from readme
- Point users to `:help live-server.nvim` for detailed documentation
- Keep readme minimal following the cp.nvim style

## Test plan
- [ ] Verify readme displays correctly on GitHub
- [ ] Verify vimdoc contains all necessary config and usage info