### PR TITLE
fix: add one-time deprecation notice for Neovim < 0.10

### DIFF
--- a/plugin/live-server.lua
+++ b/plugin/live-server.lua
@@ -1,3 +1,16 @@
+if vim.fn.has('nvim-0.10') == 0 then
+  local marker = vim.fn.stdpath('data') .. '/live-server-version-notice'
+  if vim.fn.filereadable(marker) == 0 then
+    vim.notify(
+      'live-server.nvim v0.2.0 will require Neovim >= 0.10.\n'
+        .. 'To keep using this plugin, pin to the v0.1.6 tag:\n\n'
+        .. '  { "barrettruth/live-server.nvim", tag = "v0.1.6" }',
+      vim.log.levels.WARN
+    )
+    vim.fn.writefile({}, marker)
+  end
+end
+
 if vim.g.loaded_live_server then
   return
 end


### PR DESCRIPTION
## Problem

v0.2.0 will replace the npm `live-server` dependency with a pure-Lua HTTP
server that requires Neovim >= 0.10 (`vim.uv`, `vim.ui.open`). Users on
older Neovim versions who auto-update will get a cryptic Lua error with no
explanation or migration path.

## Solution

Add a one-time notification at plugin load time for Neovim < 0.10 users.
The notice tells them v0.2.0 will require Neovim >= 0.10 and shows how to
pin to the `v0.1.6` tag. A marker file in `stdpath('data')` ensures the
message fires exactly once, ever. The plugin continues to work normally
after the notice — no functionality is removed.

This is the last release supporting Neovim < 0.10 and npm `live-server`.
Tag as `v0.1.6` after merge.