### PR TITLE
fix: prevent infinite loop when started from non-filesystem buffer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -65,12 +65,11 @@ body:
       value: |
         vim.env.LAZY_STDPATH = '.repro'
         load(vim.fn.system('curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua'))()
-        require('lazy.nvim').setup({
+        require('lazy').setup({
           spec = {
             {
               'barrett-ruth/live-server.nvim',
               lazy = false,
-              opts = {},
             },
           },
         })

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -69,6 +69,7 @@ body:
           spec = {
             {
               'barrett-ruth/live-server.nvim',
+              lazy = false,
               opts = {},
             },
           },

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 .envrc
 .direnv
+
+.repro
+repro.lua

--- a/lua/live-server/init.lua
+++ b/lua/live-server/init.lua
@@ -160,7 +160,9 @@ end
 ---@return string
 local function resolve_dir(dir)
   if not dir or dir == '' then
-    dir = '%:p:h'
+    local bufname = vim.api.nvim_buf_get_name(0)
+    local uri_path = bufname:match('^%a+://(/.*)')
+    dir = uri_path or '%:p:h'
   end
   return vim.fn.expand(vim.fn.fnamemodify(vim.fn.expand(dir), ':p'))
 end

--- a/lua/live-server/init.lua
+++ b/lua/live-server/init.lua
@@ -140,7 +140,11 @@ local function find_cached_dir(dir)
     if cur == '/' or cur:match('^[A-Z]:\\$') then
       return nil
     end
-    cur = vim.fn.fnamemodify(cur, ':h')
+    local parent = vim.fn.fnamemodify(cur, ':h')
+    if parent == cur then
+      return nil
+    end
+    cur = parent
   end
   return cur
 end


### PR DESCRIPTION
## Problem

Calling \`:LiveServerStart\` from an oil.nvim buffer (or any URI-scheme buffer) caused two issues: first, \`find_cached_dir\` entered an infinite loop as \`fnamemodify(cur, ':h')\` degenerated to \`.\`, freezing Neovim and pegging the CPU; second, even after fixing the loop, the server would error out instead of doing the right thing — serving the directory being browsed.

## Solution

Add a progress check to \`find_cached_dir\` so it bails if the path stops changing. Fix \`resolve_dir\` to detect URI-scheme buffer names (e.g. \`oil:///path/to/dir\`) and extract the real filesystem path from them, so \`:LiveServerStart\` correctly serves the browsed directory. Also corrects the bug report repro template (\`require('lazy')\`, \`lazy = false\`, no deprecated \`opts\`) and ignores \`repro.lua\`.

Closes #34