### PR TITLE
feat: emit `User` autocommand events for server lifecycle

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -74,8 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run:
-          nix develop --command vimdoc-language-server check doc/
+      - run: nix develop --command vimdoc-language-server check doc/
           --no-runtime-tags
 
   markdown-format:

--- a/doc/live-server.txt
+++ b/doc/live-server.txt
@@ -108,6 +108,35 @@ live_server.setup({user_config})                         *live_server.setup()*
         {user_config}  (|live_server.Config|?) Configuration table
 
 ===============================================================================
+EVENTS                                                  *live-server-events*
+
+live-server.nvim fires |User| autocommands at key lifecycle points. Event
+data is available via `args.data` in the callback.
+
+                                                       *LiveServerStarted*
+LiveServerStarted       Fired after the server starts listening.
+                        Data: `{ port: integer, root: string }`
+
+                                                       *LiveServerStopped*
+LiveServerStopped       Fired after the server stops (including on
+                        |VimLeavePre|).
+                        Data: `{ port: integer, root: string }`
+
+                                                       *LiveServerReload*
+LiveServerReload        Fired when a file change triggers a browser reload.
+                        Data: `{ root: string, css_only: boolean }`
+
+Example: >lua
+    vim.api.nvim_create_autocmd('User', {
+        pattern = 'LiveServerStarted',
+        callback = function(args)
+            print('Serving ' .. args.data.root
+                .. ' on port ' .. args.data.port)
+        end,
+    })
+<
+
+===============================================================================
 EXAMPLES                                               *live-server-examples*
 
 Start server in project root: >vim

--- a/doc/live-server.txt
+++ b/doc/live-server.txt
@@ -38,7 +38,7 @@ Fields: ~
     {css_inject} (`boolean?`) Hot-swap CSS without full page reload.
                 Default: `true`
     {debug}     (`boolean?`) Log each step of the hot-reload chain via
-                |vim.notify()| at DEBUG level. Default: `false`
+                `vim.notify()` at DEBUG level. Default: `false`
 
 ===============================================================================
 COMMANDS                                               *live-server-commands*
@@ -110,7 +110,7 @@ live_server.setup({user_config})                         *live_server.setup()*
 ===============================================================================
 EVENTS                                                  *live-server-events*
 
-live-server.nvim fires |User| autocommands at key lifecycle points. Event
+live-server.nvim fires `User` autocommands at key lifecycle points. Event
 data is available via `args.data` in the callback.
 
                                                        *LiveServerStarted*
@@ -119,7 +119,7 @@ LiveServerStarted       Fired after the server starts listening.
 
                                                        *LiveServerStopped*
 LiveServerStopped       Fired after the server stops (including on
-                        |VimLeavePre|).
+                        `VimLeavePre`).
                         Data: `{ port: integer, root: string }`
 
                                                        *LiveServerReload*

--- a/lua/live-server/init.lua
+++ b/lua/live-server/init.lua
@@ -121,6 +121,10 @@ local function init()
       for dir, inst in pairs(instances) do
         server.stop(inst)
         instances[dir] = nil
+        vim.api.nvim_exec_autocmds('User', {
+          pattern = 'LiveServerStopped',
+          data = { port = inst.port, root = inst.root_real },
+        })
       end
     end,
   })
@@ -196,6 +200,11 @@ function M.start(dir)
   instances[dir] = inst
   log(('started on 127.0.0.1:%d'):format(config.port), 'INFO')
 
+  vim.api.nvim_exec_autocmds('User', {
+    pattern = 'LiveServerStarted',
+    data = { port = config.port, root = root_real },
+  })
+
   if config.browser then
     vim.ui.open(('http://127.0.0.1:%d/'):format(config.port))
   end
@@ -206,9 +215,15 @@ function M.stop(dir)
   dir = resolve_dir(dir)
   local cached_dir = find_cached_dir(dir)
   if cached_dir and instances[cached_dir] then
-    server.stop(instances[cached_dir])
+    local inst = instances[cached_dir]
+    server.stop(inst)
     instances[cached_dir] = nil
     log('stopped', 'INFO')
+
+    vim.api.nvim_exec_autocmds('User', {
+      pattern = 'LiveServerStopped',
+      data = { port = inst.port, root = inst.root_real },
+    })
   end
 end
 

--- a/lua/live-server/server.lua
+++ b/lua/live-server/server.lua
@@ -631,6 +631,11 @@ function S.reload(inst, css_only)
     )
   )
   sse_broadcast(inst, 'reload', payload)
+
+  vim.api.nvim_exec_autocmds('User', {
+    pattern = 'LiveServerReload',
+    data = { root = inst.root_real, css_only = use_css },
+  })
 end
 
 return S


### PR DESCRIPTION
## Problem

There was no way for external code to react to live-server state changes such as starting, stopping, or reloading.

## Solution

Fire `LiveServerStarted`, `LiveServerStopped`, and `LiveServerReload` `User` autocommands with relevant data (`port`, `root`, `css_only`) at each lifecycle point. Document the new events in vimdoc under a new `EVENTS` section.