### PR TITLE
Prepare the v0.2.0 release path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+name: ci
+
+on:
+  workflow_call:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: ./scripts/ci.sh

--- a/doc/live-server.nvim.txt
+++ b/doc/live-server.nvim.txt
@@ -26,6 +26,9 @@ Configure via `vim.g.live_server` before the plugin loads: >lua
         browser = false,
     }
 <
+The legacy `args` config and `require('live-server').setup()` API were removed
+in `v0.2.0`.
+
                                                           *live_server.Config*
 Fields: ~
 
@@ -100,12 +103,6 @@ live_server.toggle({dir})                               *live_server.toggle()*
 
     Parameters: ~
         {dir}  (`string?`) Directory to toggle
-
-live_server.setup({user_config})                         *live_server.setup()*
-    Deprecated: Use |vim.g.live_server| instead.
-
-    Parameters: ~
-        {user_config}  (|live_server.Config|?) Configuration table
 
 ==============================================================================
 EVENTS                                                    *live-server-events*

--- a/lua/live-server/health.lua
+++ b/lua/live-server/health.lua
@@ -20,12 +20,12 @@ function M.check()
 
   local user_config = vim.g.live_server or {}
   if user_config.args then
-    vim.health.warn(
-      'deprecated `args` config detected',
-      { 'See `:h live-server-config` for the new format' }
+    vim.health.error(
+      'removed `args` config detected',
+      { 'Use the keys documented in `:h live-server-config` instead' }
     )
   else
-    vim.health.ok('no deprecated config detected')
+    vim.health.ok('no removed config detected')
   end
 
   if jit.os == 'Linux' then

--- a/lua/live-server/init.lua
+++ b/lua/live-server/init.lua
@@ -29,6 +29,8 @@ local defaults = {
 ---@type live_server.Config
 local config = vim.deepcopy(defaults)
 
+local init_error
+
 ---@param message string
 ---@param level string
 local function log(message, level)
@@ -60,14 +62,6 @@ local function migrate_args(user_config)
     return user_config
   end
 
-  vim.deprecate(
-    '`vim.g.live_server.args`',
-    '`:h live-server-config`',
-    'v0.2.0',
-    'live-server.nvim',
-    false
-  )
-
   local migrated = {}
   for k, v in pairs(user_config) do
     if k ~= 'args' then
@@ -75,33 +69,20 @@ local function migrate_args(user_config)
     end
   end
 
+  local unsupported = {}
   for _, arg in ipairs(user_config.args) do
-    local port = arg:match('%-%-port=(%d+)')
-    if port then
-      migrated.port = tonumber(port)
-    elseif arg == '--no-browser' then
-      migrated.browser = false
-    elseif arg == '--no-css-inject' then
-      migrated.css_inject = false
-    else
-      local wait = arg:match('%-%-wait=(%d+)')
-      if wait then
-        migrated.debounce = tonumber(wait)
-      else
-        local ignore_val = arg:match('%-%-ignore=(.*)')
-        if ignore_val then
-          migrated.ignore = migrated.ignore or {}
-          for pattern in ignore_val:gmatch('[^,]+') do
-            migrated.ignore[#migrated.ignore + 1] = vim.trim(pattern)
-          end
-        else
-          local flag = arg:match('^(%-%-[%w-]+)')
-          if flag and UNSUPPORTED_FLAGS[flag] then
-            log(('flag `%s` is not supported and will be ignored'):format(arg), 'WARN')
-          end
-        end
-      end
+    local flag = arg:match('^(%-%-[%w-]+)')
+    if flag and UNSUPPORTED_FLAGS[flag] then
+      unsupported[#unsupported + 1] = arg
     end
+  end
+
+  if #unsupported == 0 then
+    init_error = '`vim.g.live_server.args` was removed in v0.2.0. See `:h live-server-config`.'
+  else
+    init_error = ('`vim.g.live_server.args` was removed in v0.2.0. Unsupported flags were configured: %s. See `:h live-server-config`.'):format(
+      table.concat(unsupported, ', ')
+    )
   end
 
   return migrated
@@ -109,11 +90,17 @@ end
 
 local function init()
   if initialized then
-    return
+    return true
   end
+
+  init_error = nil
 
   local user_config = vim.g.live_server or {}
   user_config = migrate_args(user_config)
+  if init_error then
+    log(init_error, 'ERROR')
+    return false
+  end
   config = vim.tbl_deep_extend('force', defaults, user_config)
 
   vim.api.nvim_create_autocmd('VimLeavePre', {
@@ -130,6 +117,7 @@ local function init()
   })
 
   initialized = true
+  return true
 end
 
 ---@param dir? string
@@ -173,7 +161,9 @@ end
 
 ---@param dir? string
 function M.start(dir)
-  init()
+  if not init() then
+    return
+  end
 
   dir = resolve_dir(dir)
 
@@ -240,20 +230,15 @@ end
 ---@deprecated Use `vim.g.live_server` instead
 ---@param user_config? live_server.Config
 function M.setup(user_config)
-  vim.deprecate(
-    '`require("live-server").setup()`',
-    '`vim.g.live_server`',
-    'v0.1.0',
-    'live-server.nvim',
-    false
-  )
-
+  local hint = ''
   if user_config then
-    vim.g.live_server = vim.tbl_deep_extend('force', vim.g.live_server or {}, user_config)
+    hint = ' Move the provided table to `vim.g.live_server` before the plugin loads.'
   end
-
-  initialized = false
-  init()
+  log(
+    '`require("live-server").setup()` was removed in v0.2.0. Use `vim.g.live_server` instead.'
+      .. hint,
+    'ERROR'
+  )
 end
 
 return M


### PR DESCRIPTION
## Summary
- restore the reusable CI workflow that tag-triggered LuaRocks releases expect
- stop auto-migrating the removed `vim.g.live_server.args` config and report it as an error instead
- stop supporting `require('live-server').setup()` and remove it from the help docs

#### Test plan
- [x] ./scripts/ci.sh