### PR TITLE
ci: drop --no-runtime-tags from vimdoc check

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ format:
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet
     lua-language-server --check . --checklevel=Warning
-    vimdoc-language-server check doc/ --no-runtime-tags
+    vimdoc-language-server check doc/
 
 ci: format lint
     @:


### PR DESCRIPTION
The `ci` shell already bundles Neovim via `pkgs.neovim`, so `vimdoc-language-server check doc/` resolves `$VIMRUNTIME/doc/tags` on its own. The `--no-runtime-tags` flag was suppressing real `|taglink|` validation against the bundled runtime for no benefit.
