### PR TITLE
chore: replace prettier with biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "indentStyle": "space"
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
                 nlua
               ]
             ))
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene
@@ -47,7 +47,7 @@
                 nlua
               ]
             ))
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome format .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
This replaces the repo's Prettier format check with Biome, adds a Biome config for the repo's JSON files, and swaps the Nix dev shells over to pkgs.biome. Verified with nix develop .#ci --command just format, nix develop .#ci --command just lint, and nix develop .#ci --command just ci.
